### PR TITLE
Fix occasional Freeview errors

### DIFF
--- a/scripts/update_all_tv_guides.py
+++ b/scripts/update_all_tv_guides.py
@@ -18,6 +18,10 @@ DATA_DIRECTORY = os.path.join(ROOT_DIRECTORY, 'data/')
 
 os.makedirs(RAW_DIRECTORY, exist_ok=True)
 os.makedirs(DATA_DIRECTORY, exist_ok=True)
+# Pre-create cache dir.
+cache_dir = os.path.join(ROOT_DIRECTORY, 'scripts/.xmltv/cache')
+os.makedirs(cache_dir, exist_ok=True)
+print(f"Created xmltv cache directory '{cache_dir}'.")
 
 # The date format used in XMLTV (the %Z will go away in 0.6)
 DATE_FORMAT = '%Y%m%d%H%M%S %Z'


### PR DESCRIPTION
The freeview grabber fails every now and then while creating the cache folder. 
Error message in the action log: Failed to create cache-directory /home/runner/work/xmltv/xmltv/scripts//.xmltv/cache. Last observed in the github actions log of may 16.

I'm not quite sure of the cause. It has the distinct smell of a race condition caused by multiple processes running the same grabber, but this error already occurred at the time grabbers ran in sequence. 

Whatever the cause, this PR pre-creates the XMLTV cache folder, which seems to fix it. 